### PR TITLE
Detect invalid UTF-8 bytes

### DIFF
--- a/presidio_cli/cli.py
+++ b/presidio_cli/cli.py
@@ -122,9 +122,13 @@ def find_files_recursively(items, conf):
                         if conf.is_text_file(filepath):
                             yield filepath
                     except UnicodeDecodeError:
-                        pass  # Found non-text data
+                        pass  # Found invalid UTF-8 characters
         else:
-            yield item
+            try:
+                if conf.is_text_file(item):
+                    yield item
+            except UnicodeDecodeError:
+                pass  # Found invalid UTF-8 characters
 
 
 def run():

--- a/presidio_cli/config.py
+++ b/presidio_cli/config.py
@@ -31,6 +31,13 @@ class PresidioCLIConfig(object):
         Based on https://stackoverflow.com/a/7392391
         """
 
+        # Try to read the file as UTF-8.
+        # In case some invalid UTF-8 characters are found,
+        # an exception is caught in find_files_recursively
+        # and the file is not going to be processed.
+        with open(filepath, newline="") as f:
+            content = f.read()
+
         textchars = bytearray(
             {7, 8, 9, 10, 12, 13, 27} | set(range(0x20, 0x100)) - {0x7F}
         )

--- a/presidio_cli/config.py
+++ b/presidio_cli/config.py
@@ -36,7 +36,7 @@ class PresidioCLIConfig(object):
         # an exception is caught in find_files_recursively
         # and the file is not going to be processed.
         with open(filepath, newline="") as f:
-            content = f.read()
+            _ = f.read()
 
         textchars = bytearray(
             {7, 8, 9, 10, 12, 13, 27} | set(range(0x20, 0x100)) - {0x7F}


### PR DESCRIPTION
Before trying to determine if the file is text or binary, by checking which byte ranges are present in the file, try to read the file as UTF-8. The `UnicodeDecodeError` exception raised during this reading will mean that the file is not a text file.

The exception is silently caught and file is not going to be processed further.

Correctness of the solution was tested on a generated file with bytes from the range of `{7, 8, 9, 10, 12, 13, 27} | set(range(0x20, 0x100)) - {0x7F}`.

Closes #8 